### PR TITLE
This check fails on OS X

### DIFF
--- a/lib/net/ssh/kerberos/drivers.rb
+++ b/lib/net/ssh/kerberos/drivers.rb
@@ -46,7 +46,7 @@ module Net; module SSH; module Kerberos;
 		@@available = []
     def self.available; @@available end
 
-		if %w(win dar mingw).any?{|p| RUBY_PLATFORM.include?(p)}; then
+		if RUBY_PLATFORM =~ /mingw/ || (RUBY_PLATFORM =~ /win/ && RUBY_PLATFORM !~ /darwin/)
 		  begin require 'net/ssh/kerberos/drivers/sspi'; available << 'SSPI'
 		  rescue => e
 		    raise e unless RuntimeError === e and e.message =~ /^LoadLibrary: ([^\s]+)/


### PR DESCRIPTION
The ruby platform variable for OS X: "i686-darwin10.6.0" matches both "win" and "dar" in this 'if' clause, and so the gem mistakenly attempts to load SSPI on OS X.
